### PR TITLE
Docker Fixes for v5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,37 @@
+FROM golang:1.24.2 AS builder
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the go.mod and go.sum files to the working directory
+COPY server.go go.mod go.sum /app/
+
+# Copy the source code to the working directory
+COPY ./build/ /app/build/
+COPY ./src/ /app/src/
+COPY ./UIMod/ /app/UIMod/
+
+# Download the dependencies
+RUN go mod tidy
+
+# build the application
+RUN go run ./build/build.go
+
+# Verify that the build was successful and the executable is present
+RUN echo "Verifying the build output:" && \
+    if [ -f /app/build/StationeersServerControl*.x86_64 ]; then \
+        echo "Build successful, executable found."; \
+    else \
+        echo "Error: Build failed or executable not found."; \
+        exit 1; \
+    fi
+
 FROM debian:12-slim AS runner
 
 # Set the working directory inside the container
 WORKDIR /app
 
 # Copy the rest of the application source code
-COPY ./build/StationeersServerControl*.x86_64 /app/StationeersServerControl
+COPY --from=builder /app/build/StationeersServerControl*.x86_64 /app/StationeersServerControl
 COPY ./LICENSE /app/LICENSE
 RUN chmod +x /app/StationeersServerControl
 


### PR DESCRIPTION
Add builder stage using golang:1.24.2 to compile the application
Use debian:12-slim for the final runtime image