### PR TITLE
Add Auto Restart Server Timer feature to config

### DIFF
--- a/UIMod/ui/config.html
+++ b/UIMod/ui/config.html
@@ -213,6 +213,13 @@
                                         value="{{AdditionalParams}}">
                                     <div class="input-info">Format: CustomParam1 Value1 CustomParam2 Value2</div>
                                 </div>
+
+                                <div class="form-group">
+                                    <label for="AutoRestartServerTimer">Scheduled Gameserver Restart:</label>
+                                    <input type="text" id="AutoRestartServerTimer" name="AutoRestartServerTimer"
+                                        value="{{AutoRestartServerTimer}}">
+                                    <div class="input-info">Timeframe in <strong> minutes </strong> to schedule an automatic gameserver restart. 0 = disabled, 1440 = 24 hours, etc.. If SSCM is enabled, you will see "Attention, server is restarting in 30/20/10/5 seconds!" messages <strong> ingame </strong> before restarting.</div>
+                                </div>
                             </div>
                         </div>
 
@@ -221,7 +228,7 @@
                             <button type="button" class="save-button"
                                 onclick="document.getElementById('server-config-form').submit()"></button>
                         </div>
-                    </form>
+                    </form> 
                 </div>
             </div>
         </div>

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// All configuration variables can be found in vars.go
-	Version = "5.4.31"
+	Version = "5.4.32"
 	Branch  = "release"
 )
 
@@ -63,6 +63,7 @@ type JsonConfig struct {
 	SubsystemFilters        []string          `json:"subsystemFilters"`
 	IsUpdateEnabled         *bool             `json:"IsUpdateEnabled"`
 	IsSSCMEnabled           *bool             `json:"IsSSCMEnabled"`
+	AutoRestartServerTimer  string            `json:"AutoRestartServerTimer"`
 	AllowPrereleaseUpdates  *bool             `json:"AllowPrereleaseUpdates"`
 	AllowMajorUpdates       *bool             `json:"AllowMajorUpdates"`
 }
@@ -202,7 +203,7 @@ func applyConfig(cfg *JsonConfig) {
 	cfg.AllowMajorUpdates = &allowMajorUpdatesVal
 
 	SubsystemFilters = getStringSlice(cfg.SubsystemFilters, "SUBSYSTEM_FILTERS", []string{})
-
+	AutoRestartServerTimer = getString(cfg.AutoRestartServerTimer, "AUTO_RESTART_SERVER_TIMER", "0")
 	isSSCMEnabledVal := getBool(cfg.IsSSCMEnabled, "IS_SSCM_ENABLED", false)
 	IsSSCMEnabled = isSSCMEnabledVal
 	cfg.IsSSCMEnabled = &isSSCMEnabledVal

--- a/src/config/vars.go
+++ b/src/config/vars.go
@@ -47,19 +47,20 @@ var (
 
 // Logging, debugging and misc
 var (
-	IsDebugMode          bool //only used for pprof server, keep it like this and check the log level instead. Debug = 10
-	CreateSSUILogFile    bool
-	LogLevel             int
-	LogMessageBuffer     string
-	IsFirstTimeSetup     bool
-	BufferFlushTicker    *time.Ticker
-	SSEMessageBufferSize = 2000
-	MaxSSEConnections    = 20
-	GameServerAppID      = "600760"
-	ExePath              string
-	GameBranch           string
-	SubsystemFilters     []string
-	GameServerUUID       uuid.UUID // Assined at startup to the current instance of the server we are managing. Currently unused.
+	IsDebugMode            bool //only used for pprof server, keep it like this and check the log level instead. Debug = 10
+	CreateSSUILogFile      bool
+	LogLevel               int
+	LogMessageBuffer       string
+	IsFirstTimeSetup       bool
+	BufferFlushTicker      *time.Ticker
+	SSEMessageBufferSize   = 2000
+	MaxSSEConnections      = 20
+	GameServerAppID        = "600760"
+	ExePath                string
+	GameBranch             string
+	SubsystemFilters       []string
+	GameServerUUID         uuid.UUID // Assined at startup to the current instance of the server we are managing. Currently unused.
+	AutoRestartServerTimer string
 )
 
 // Discord integration

--- a/src/web/http.go
+++ b/src/web/http.go
@@ -172,6 +172,7 @@ func ServeConfigPage(w http.ResponseWriter, r *http.Request) {
 		"{{UseSteamP2PFalseSelected}}":      steamP2PFalseSelected,
 		"{{ExePath}}":                       config.ExePath,
 		"{{AdditionalParams}}":              config.AdditionalParams,
+		"{{AutoRestartServerTimer}}":        config.AutoRestartServerTimer,
 	}
 
 	for placeholder, value := range replacements {


### PR DESCRIPTION
- Introduced "Scheduled Gameserver Restart"  (AutoRestartServerTimer) input in config.html for user-defined server restart scheduling.
- Updated version to 5.4.32
- added AutoRestartServerTimer to persistent configuration variables.
- Implemented auto-restart logic in processmanagement.go, allowing server to restart based on the specified timeframe.
- Updated ServeConfigPage to include AutoRestartServerTimer in the configuration response.
<img width="457" height="415" alt="image" src="https://github.com/user-attachments/assets/bab1c300-a7ed-4106-81bf-82fd0b81e9ba" />
<img width="1010" height="136" alt="image" src="https://github.com/user-attachments/assets/8c948af0-9ddf-4fc8-af81-931a615c1b49" />
