### PR TITLE
Update Dockerfile and Docker-Compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -18,7 +18,14 @@ services:
       - "27015:27015/udp"
       - "27015:27015/tcp"
     volumes:
-      - ./saves:/app/saves
+      # Persist app data between container restarts
+      - app-data:/app
+      # Mount saves and config for easy access/editing outside the container
+      - ./saves:/app/saves:rw
       - ./UIMod/config:/app/UIMod/config:rw
+      - ./UIMod/tls:/app/UIMod/tls:rw
     restart: unless-stopped
     command: []
+
+volumes:
+  app-data:


### PR DESCRIPTION
This PR refactors the existing Dockerfile with:

- a multi-stage-build
- layer caching
- rootless containers

_( Now you can add rootless container as another security buzzword! ;> )_

Additionally, I've changed the docker-compose to take advantage of the above- and also included some volume configuration, in particular:

```yaml
  volumes:
      # Persist app data between container restarts
      - app-data:/app
      # Mount saves and config for easy access/editing outside the container
      - ./saves:/app/saves:rw
      - ./UIMod/config:/app/UIMod/config:rw
      - ./UIMod/tls:/app/UIMod/tls:rw
```

Including the volume (and the mount overrides) allows us to maintain persistence between restarts, and also maintains performance _(mounts are notorious for killing file i/o)_

## Changes

- **added Github CodeQL**
- **(frontend) upd. dependencies and rm electron entirely**
- **refactor: update Dockerfile and compose.yml with rootless containers and multi-stage build process**
