### PR TITLE
fix steamcmd writing to HOME dir & add sanitycheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ UIMod/tls/cert.pem
 UIMod/tls/key.pem
 steamapps/**
 steamcmd/**
+Steam/**
 rocketstation_BurstDebugInformation_DoNotShip/**
 StationeersServerControlv*
 UnityPlayer.so

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,16 @@
             "program": "${workspaceFolder}/server.go",
             "console": "integratedTerminal",
             "showLog": false, // Hides some Go Debugger(Delve) log stuff that is not useful for debugging atm
+        },
+        {
+            "name": "Debug Go Server noSteamCMD noSvelte",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/server.go",
+            "console": "integratedTerminal",
+            "showLog": false, // Hides some Go Debugger(Delve) log stuff that is not useful for debugging atm
+            "args": ["--SkipSteamCMD"]
         }
     ]
 }

--- a/server.go
+++ b/server.go
@@ -39,7 +39,6 @@ var v1uiFS embed.FS
 func main() {
 	var wg sync.WaitGroup
 	logger.ConfigureConsole()
-	loader.SetupWorkingDir()
 	if err := loader.SanityCheck(); err != nil {
 		logger.Main.Error("Sanity check failed, exiting in 10 secconds: " + err.Error())
 		time.Sleep(10 * time.Second)

--- a/server.go
+++ b/server.go
@@ -22,9 +22,7 @@ package main
 
 import (
 	"embed"
-	"os"
 	"sync"
-	"time"
 
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/cli"
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/core/loader"
@@ -39,11 +37,8 @@ var v1uiFS embed.FS
 func main() {
 	var wg sync.WaitGroup
 	logger.ConfigureConsole()
-	if err := loader.SanityCheck(); err != nil {
-		logger.Main.Error("Sanity check failed, exiting in 10 secconds: " + err.Error())
-		time.Sleep(10 * time.Second)
-		os.Exit(1)
-	}
+	loader.SanityCheck(&wg)
+	wg.Wait()
 	logger.Main.Debug("Initializing resources...")
 	loader.InitVirtFS(v1uiFS)
 	logger.Install.Info("Starting setup...")

--- a/server.go
+++ b/server.go
@@ -22,7 +22,9 @@ package main
 
 import (
 	"embed"
+	"os"
 	"sync"
+	"time"
 
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/cli"
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/core/loader"
@@ -38,6 +40,11 @@ func main() {
 	var wg sync.WaitGroup
 	logger.ConfigureConsole()
 	loader.SetupWorkingDir()
+	if err := loader.SanityCheck(); err != nil {
+		logger.Main.Error("Sanity check failed, exiting in 10 secconds: " + err.Error())
+		time.Sleep(10 * time.Second)
+		os.Exit(1)
+	}
 	logger.Main.Debug("Initializing resources...")
 	loader.InitVirtFS(v1uiFS)
 	logger.Install.Info("Starting setup...")

--- a/src/config/getters.go
+++ b/src/config/getters.go
@@ -493,3 +493,9 @@ func GetExtractedGameVersion() string {
 	defer ConfigMu.RUnlock()
 	return ExtractedGameVersion
 }
+
+func GetSkipSteamCMD() bool {
+	ConfigMu.RLock()
+	defer ConfigMu.RUnlock()
+	return SkipSteamCMD
+}

--- a/src/config/setters.go
+++ b/src/config/setters.go
@@ -54,6 +54,14 @@ func SetSkipSteamCMD(value bool) error {
 	return nil
 }
 
+func SetIsDockerContainer(value bool) error {
+	ConfigMu.Lock()
+	defer ConfigMu.Unlock()
+
+	IsDockerContainer = value
+	return nil
+}
+
 // ALL SETTERS BELOW THIS LINE ARE UNUSED AT THE MOMENT
 // ALL SETTERS BELOW THIS LINE ARE UNUSED AT THE MOMENT
 // ALL SETTERS BELOW THIS LINE ARE UNUSED AT THE MOMENT

--- a/src/config/setters.go
+++ b/src/config/setters.go
@@ -46,6 +46,14 @@ func SetExtractedGameVersion(value string) error {
 	return nil
 }
 
+func SetSkipSteamCMD(value bool) error {
+	ConfigMu.Lock()
+	defer ConfigMu.Unlock()
+
+	SkipSteamCMD = value
+	return nil
+}
+
 // ALL SETTERS BELOW THIS LINE ARE UNUSED AT THE MOMENT
 // ALL SETTERS BELOW THIS LINE ARE UNUSED AT THE MOMENT
 // ALL SETTERS BELOW THIS LINE ARE UNUSED AT THE MOMENT

--- a/src/config/vars.go
+++ b/src/config/vars.go
@@ -61,9 +61,15 @@ var (
 	LanguageSetting          string
 	AutoStartServerOnStartup bool
 	SSUIIdentifier           string
-	CurrentBranchBuildID     string // ONLY RUNTIME
-	ExtractedGameVersion     string // ONLY RUNTIME
-	SkipSteamCMD             bool   // ONLY RUNTIME
+)
+
+// Runtime only variables
+
+var (
+	CurrentBranchBuildID string // ONLY RUNTIME
+	ExtractedGameVersion string // ONLY RUNTIME
+	SkipSteamCMD         bool   // ONLY RUNTIME
+	IsDockerContainer    bool   // ONLY RUNTIME
 )
 
 // Discord integration

--- a/src/config/vars.go
+++ b/src/config/vars.go
@@ -63,6 +63,7 @@ var (
 	SSUIIdentifier           string
 	CurrentBranchBuildID     string // ONLY RUNTIME
 	ExtractedGameVersion     string // ONLY RUNTIME
+	SkipSteamCMD             bool   // ONLY RUNTIME
 )
 
 // Discord integration

--- a/src/core/loader/cmdargs.go
+++ b/src/core/loader/cmdargs.go
@@ -21,6 +21,7 @@ func LoadCmdArgs() {
 	var createSSUILogFile bool
 	var recoveryPassword string
 	var devMode bool
+	var skipSteamCMD bool
 
 	flag.StringVar(&backendEndpointPort, "BackendEndpointPort", "", "Override the backend endpoint port (e.g., 8080)")
 	flag.StringVar(&backendEndpointPort, "p", "", "(Alias) Override the backend endpoint port (e.g., 8080)")
@@ -35,6 +36,8 @@ func LoadCmdArgs() {
 	flag.BoolVar(&isDebugMode, "debug", false, "(Alias) Enable debug mode")
 	flag.BoolVar(&createSSUILogFile, "CreateSSUILogFile", false, "Create a log file for SSUI")
 	flag.BoolVar(&createSSUILogFile, "lf", false, "(Alias) Create a log file for SSUI")
+	flag.BoolVar(&skipSteamCMD, "SkipSteamCMD", false, "Skips SteamCMD installation")
+	flag.BoolVar(&skipSteamCMD, "nosteam", false, "(Alias) Skips SteamCMD installation")
 
 	// Parse command-line flags
 	flag.Parse()
@@ -45,6 +48,10 @@ func LoadCmdArgs() {
 		config.SetUsers(map[string]string{"admin": "$2a$10$7QQhPkNAfT.MXhJhnnodXOyn3KKE/1eu7nYb0y2O1UBoAWc0Y/fda"}) // admin:admin
 		config.SetIsConsoleEnabled(true)
 		logger.Main.Info("Dev mode enabled: Auth enabled, admin user set to admin:admin:superadmin, console enabled")
+	}
+
+	if skipSteamCMD {
+		config.SetSkipSteamCMD(true)
 	}
 
 	if backendEndpointPort != "" && backendEndpointPort != "8443" {

--- a/src/core/loader/helpers.go
+++ b/src/core/loader/helpers.go
@@ -195,3 +195,39 @@ func SetupWorkingDir() error {
 	}
 	return nil
 }
+
+func SanityCheck() error {
+
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	// Check if running as root (UID 0)
+	if os.Geteuid() == 0 {
+		return fmt.Errorf("root: SSUI should not be run as root")
+	}
+
+	// Check if current working directory is writable
+	workDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Try to create a temporary file to test write permissions
+	testFile := filepath.Join(workDir, ".write_test")
+	if err := os.WriteFile(testFile, []byte("test"), 0600); err != nil {
+		return fmt.Errorf("cannot write to working directory %s: %w", workDir, err)
+	}
+	// Clean up test file
+	if err := os.Remove(testFile); err != nil {
+		return fmt.Errorf("failed to clean up sanity check writetest file: %w", err)
+	}
+
+	// Check if steamcmd package is installed  (requires further testing, disabled for now)
+	//cmd := exec.Command("dpkg-query", "-W", "-f='${Status}'", "steamcmd")
+	//output, err := cmd.CombinedOutput()
+	//if err == nil && strings.Contains(string(output), "install ok installed") {
+	//	return fmt.Errorf("steamcmd package is installed")
+	//}
+
+	return nil
+}

--- a/src/core/loader/loader.go
+++ b/src/core/loader/loader.go
@@ -3,7 +3,9 @@ package loader
 
 import (
 	"embed"
+	"os"
 	"sync"
+	"time"
 
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/config"
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/discordbot"
@@ -97,4 +99,14 @@ func ReloadAppInfoPoller() {
 // InitBundler initialized the onboard bundled assets for the web UI
 func InitVirtFS(v1uiFS embed.FS) {
 	config.SetV1UIFS(v1uiFS)
+}
+
+func SanityCheck(wg *sync.WaitGroup) {
+	defer wg.Done()
+	err := runSanityCheck()
+	if err != nil {
+		logger.Main.Error("Sanity check failed, exiting in 10 secconds: " + err.Error())
+		time.Sleep(10 * time.Second)
+		os.Exit(1)
+	}
 }

--- a/src/core/loader/loader.go
+++ b/src/core/loader/loader.go
@@ -102,6 +102,7 @@ func InitVirtFS(v1uiFS embed.FS) {
 }
 
 func SanityCheck(wg *sync.WaitGroup) {
+	wg.Add(1)
 	defer wg.Done()
 	err := runSanityCheck()
 	if err != nil {

--- a/src/core/loader/sanitycheck.go
+++ b/src/core/loader/sanitycheck.go
@@ -1,0 +1,69 @@
+package loader
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runSanityCheck() error {
+
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	// Check if running as root (UID 0)
+	if os.Geteuid() == 0 {
+		// Check if running inside a container
+		if !IsInsideContainer() {
+			return fmt.Errorf("root: SSUI should not be run as root")
+		}
+	}
+
+	// Get the current executable path from /proc/self/exe
+	exePath, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		return err
+	}
+	// Get the directory path of the executable
+	dirPath := filepath.Dir(exePath)
+	// Change the working directory to the executable's directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	if cwd != dirPath && !strings.Contains(dirPath, "/tmp") {
+		err = os.Chdir(dirPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check if current working directory is writable
+	workDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Try to create a temporary file to test write permissions
+	testFile := filepath.Join(workDir, ".write_test")
+	if err := os.WriteFile(testFile, []byte("test"), 0600); err != nil {
+		return fmt.Errorf("cannot write to working directory, please make sure your user has write permissions in %s: %w", workDir, err)
+	}
+	// Clean up test file
+	if err := os.Remove(testFile); err != nil {
+		return fmt.Errorf("failed to clean up sanity check writetest file: %w", err)
+	}
+
+	// Check if steamcmd package is installed  (requires further testing, disabled for now)
+	//cmd := exec.Command("dpkg-query", "-W", "-f='${Status}'", "steamcmd")
+	//output, err := cmd.CombinedOutput()
+	//if err == nil && strings.Contains(string(output), "install ok installed") {
+	//	return fmt.Errorf("steamcmd package is installed")
+	//}
+
+	return nil
+}

--- a/src/setup/install.go
+++ b/src/setup/install.go
@@ -42,7 +42,9 @@ func Install(wg *sync.WaitGroup) {
 	logger.Install.Info("✅Blacklist.txt verified or created.")
 	// Step 3: Install and run SteamCMD
 	logger.Install.Info("🔄Installing and running SteamCMD...")
-	if config.GetBranch() != "indev-no-steamcmd" {
+	if config.GetSkipSteamCMD() {
+		logger.Install.Info("✅Skipping SteamCMD installation, SkipSteamCMD is true")
+	} else {
 		steamcmd.InstallAndRunSteamCMD()
 	}
 	logger.Install.Info("✅Setup complete!")

--- a/src/steamcmd/steamcmd.go
+++ b/src/steamcmd/steamcmd.go
@@ -101,6 +101,25 @@ func runSteamCMD(steamCMDDir string) (int, error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
+	if runtime.GOOS == "linux" {
+		env := os.Environ()
+		// Replace or set HOME
+		newEnv := make([]string, 0, len(env)+1)
+		foundHome := false
+		for _, e := range env {
+			if !strings.HasPrefix(e, "HOME=") {
+				newEnv = append(newEnv, e)
+			} else {
+				newEnv = append(newEnv, "HOME="+currentDir)
+				foundHome = true
+			}
+		}
+		if !foundHome {
+			newEnv = append(newEnv, "HOME="+currentDir)
+		}
+		cmd.Env = newEnv
+	}
+
 	// Run the command
 	if config.GetLogLevel() == 10 {
 		cmdString := strings.Join(cmd.Args, " ")


### PR DESCRIPTION
This PR adds some checks to detect user misconfigurations such as running as root, wrong workdirs and most importantly if the SSUI dir (main dir) is unwritable.
It also introduces logic to set the env var of HOME to the current DIR exclusively for steamcmd commands so steamcmd does not write or rely on files in the ~/Steam folder.
This also adds a IsDockerContainer (defaults to false) var (with getters and setters for future use) and a  -SkipSteamCMD / -nosteam (alias) CLI arg.