### PR TITLE
Fix race condition in SSE handling

### DIFF
--- a/src/core/ssestream/ssemanager.go
+++ b/src/core/ssestream/ssemanager.go
@@ -106,10 +106,7 @@ func (m *SSEManager) CreateStreamHandler(streamType string) http.HandlerFunc {
 		notify := r.Context().Done()
 
 		// Start streaming messages
-		go m.streamMessages(w, flusher, client, streamType, notify)
-
-		// Wait for client disconnection
-		<-notify
+		m.streamMessages(w, flusher, client, streamType, notify)
 	}
 }
 


### PR DESCRIPTION
The race condition between writing to the Http2 Response Writer occurs when SSE connection is closed, but the Fprintf formatting code is still executing.
```
panic: Write called after Handler finished

goroutine 9953 [running]:
net/http.(*http2responseWriter).write(0x2?, 0xc0000944e0?, {0xc000096500?, 0x7ff6153450be?, 0x7ff615d95060?}, {0x0?, 0xc000500808?})
        /usr/local/go/src/net/http/h2_bundle.go:6987 +0x13f
net/http.(*http2responseWriter).Write(0xc0000944e0?, {0xc000096500?, 0xa?, 0xc000391f50?})
        /usr/local/go/src/net/http/h2_bundle.go:6976 +0x2a
fmt.Fprintf({0x2426bb5a1a0, 0xc0001982d0}, {0x7ff61584992c, 0xa}, {0xc000391f50, 0x1, 0x1})
        /usr/local/go/src/fmt/print.go:225 +0x97
github.com/JacksonTheMaster/StationeersServerUI/v5/src/core/ssestream.(*SSEManager).streamMessages(0x0?, {0x7ff6159deac0, 0xc0001982d0}, {0x2426b765b58, 0xc0001982d0}, 0xc0001708a0, {0x0?, 0x0?}, 0xc0002f0150)
        src/core/ssestream/ssemanager.go:113 +0x1b6
created by github.com/JacksonTheMaster/StationeersServerUI/v5/src/web.GetLogOutput.StartConsoleStream.(*SSEManager).CreateStreamHandler.func1 in goroutine 9952
        src/core/ssestream/ssemanager.go:93 +0x409
```

This is due to concurrent closing of the underlaying Http2 Response Writer and Formatting message

Reproducer via artificial delay:
```
    for {
        select {
        case msg := <-client.messages:
            time.Sleep(300 * time.Millisecond)
            _, err := fmt.Fprintf(w, "data: %s\n\n", msg)
            if err != nil {
                logger.SSE.Error(" ❌ Failed to send message: " + err.Error())
                return
            }
            flusher.Flush()

        case <-notify:
            return
        }
    }
```

Separate goroutine is removed to fix the concurrency, and properly control response writer lifecycle