### PR TITLE
Add saving of the server output to daily log files

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -57,6 +57,8 @@ type JsonConfig struct {
 	SubsystemFilters     []string `json:"subsystemFilters"`
 	OverrideAdvertisedIp string   `json:"OverrideAdvertisedIp"`
 
+	LogServerOutputToFile *bool `json:"LogServerOutputToFile"`
+
 	// Authentication Settings
 	Users             map[string]string `json:"users"`       // Map of username to hashed password
 	AuthEnabled       *bool             `json:"authEnabled"` // Toggle for enabling/disabling auth
@@ -232,6 +234,10 @@ func applyConfig(cfg *JsonConfig) {
 
 	LogLevel = getInt(cfg.LogLevel, "LOG_LEVEL", 20)
 
+	LogServerOutputToFileVal := getBool(cfg.LogServerOutputToFile, "LOG_SERVER_OUTPUT_TO_FILE", true)
+	LogServerOutputToFile = LogServerOutputToFileVal
+	cfg.LogServerOutputToFile = &LogServerOutputToFileVal
+
 	isUpdateEnabledVal := getBool(cfg.IsUpdateEnabled, "IS_UPDATE_ENABLED", true)
 	IsUpdateEnabled = isUpdateEnabledVal
 	cfg.IsUpdateEnabled = &isUpdateEnabledVal
@@ -357,6 +363,7 @@ func safeSaveConfig() error {
 		LogLevel:                   LogLevel,
 		LogClutterToConsole:        &LogClutterToConsole,
 		SubsystemFilters:           SubsystemFilters,
+		LogServerOutputToFile:      &LogServerOutputToFile,
 		IsUpdateEnabled:            &IsUpdateEnabled,
 		IsSSCMEnabled:              &IsSSCMEnabled,
 		AutoRestartServerTimer:     AutoRestartServerTimer,

--- a/src/config/vars.go
+++ b/src/config/vars.go
@@ -58,6 +58,7 @@ var (
 	AutoRestartServerTimer   string
 	IsConsoleEnabled         bool
 	LogClutterToConsole      bool // surpresses clutter mono logs from the gameserver
+	LogServerOutputToFile    bool
 	LanguageSetting          string
 	AutoStartServerOnStartup bool
 	SSUIIdentifier           string

--- a/src/managers/detectionmgr/logstream.go
+++ b/src/managers/detectionmgr/logstream.go
@@ -2,6 +2,10 @@
 package detectionmgr
 
 import (
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/config"
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/core/ssestream"
 	"github.com/JacksonTheMaster/StationeersServerUI/v5/src/discordbot"
@@ -14,6 +18,7 @@ Real-time Log Processing Pipeline
 - Performs log enrichment and distribution:
   - Adds logs to the Discord integrations log buffer if enabled
   - Feeds messages to Detector
+  - Optionally logs messages to daily log files
 */
 
 // StartLogStream starts processing logs directly from the internal SSE manager
@@ -29,4 +34,50 @@ func StreamLogs(detector *Detector) {
 			ProcessLog(detector, logMessage)
 		}
 	}()
+
+	if config.LogServerOutputToFile {
+		logChan2 := ssestream.ConsoleStreamManager.AddInternalSubscriber()
+		f, _ := OpenLogFile(nil)
+		go func() {
+			logger.Core.Debug("LogOutput: Connected to internal log stream.")
+			for logMessage := range logChan2 {
+				f, _ = OpenLogFile(f)
+				SaveGameLogLine(f, logMessage)
+			}
+		}()
+	}
+}
+
+func OpenLogFile(prev *os.File) (*os.File, error) {
+	logFile := "server_logs/" + time.Now().Format("2006-01-02") + ".log"
+
+	if prev != nil {
+		if prev.Name() != logFile {
+			prev.Close()
+		} else {
+			return prev, nil
+		}
+	}
+
+	logger.Core.Info("Opening log file: " + logFile)
+
+	if err := os.MkdirAll(filepath.Dir(logFile), os.ModePerm); err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		logger.Core.Error("Can't open server.log: " + err.Error())
+		return nil, err
+	}
+	return f, nil
+}
+
+func SaveGameLogLine(output *os.File, logLine string) {
+	if output == nil {
+		return
+	}
+	if _, err := output.WriteString(logLine + "\n"); err != nil {
+		logger.Core.Error("Can't write log message to server.log: " + err.Error())
+	}
 }


### PR DESCRIPTION
Directory used `server_logs/` and logs are separated by date. Respects LogClutterToConsole setting and doesn't waste your disk space with random noise